### PR TITLE
fix(koolna-git-clone): export GIT_CONFIG_GLOBAL for credential helper

### DIFF
--- a/apps/koolna-git-clone/CHANGELOG.md
+++ b/apps/koolna-git-clone/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **koolna-git-clone**: export `GIT_CONFIG_GLOBAL` before cloning so git reads the credential helper written to `/cache/.koolna/.gitconfig` (private repo clones previously failed with "could not read Username")
+
 ### Added
 
 - **koolna-git-clone**: new init-container image replacing the inline `alpine/git` script that the koolna-operator previously embedded in the pod template

--- a/apps/koolna-git-clone/clone.sh
+++ b/apps/koolna-git-clone/clone.sh
@@ -19,6 +19,11 @@ KOOLNA_DIR=/cache/.koolna
 CRED="$KOOLNA_DIR/.git-credentials"
 GC="$KOOLNA_DIR/.gitconfig"
 
+# Point git at our gitconfig so it picks up the credential helper we write
+# below during the clone. Without this, git falls back to $HOME/.gitconfig -
+# empty in this container - and the clone prompts for a username and fails.
+export GIT_CONFIG_GLOBAL="$GC"
+
 mkdir -p "$KOOLNA_DIR"
 
 if [ -n "${GIT_USERNAME:-}" ] && [ -n "${GIT_TOKEN:-}" ]; then


### PR DESCRIPTION
Private-repo clone failed in the new init container with `fatal: could not read Username for 'https://github.com'`. The credential helper was written to `/cache/.koolna/.gitconfig` but git didn't read it - it fell back to `$HOME/.gitconfig` (empty). The previous inline script worked because the operator set `GIT_CONFIG_GLOBAL` as container env.

Export `GIT_CONFIG_GLOBAL` inside the script so the behaviour is self-contained.

## Test plan
- [ ] Wait for CI to build/push
- [ ] Recreate test-private, confirm git-clone succeeds